### PR TITLE
Allow more / case-insensitive inputs for os.

### DIFF
--- a/.github/workflows/bazelisk.yml
+++ b/.github/workflows/bazelisk.yml
@@ -1,0 +1,25 @@
+name: validate action
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  instal-bazelisk:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      # validate the action works with "default parameters"
+      - name: use vsco/bazelisk-action
+        uses: ./
+        with:
+          os: ${{ runner.os }}
+      - name: Validate bazel install
+        run: |
+          touch WORKSPACE
+          bazel info

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ jobs:
   steps:
     - name: Checkout
       uses: actions/checkout@v2
-      
     - name: Install Bazelisk
       uses: vsco/bazelisk-action@v1.0.0
       with:
@@ -21,7 +20,8 @@ jobs:
         # Install path for Bazelisk binaries, defaults to ./.local/bin
         bazel-install-path: './.local/bin'
         # [required]
-        # The OS of the system that wishes to install Bazelisk. Can be 'darwin' or 'linux'
+        # The OS of the system that wishes to install Bazelisk.
+        # acceptable values (case-insensitive): ['linux', 'darwin', 'macos']
         os: 'linux'
 ```
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4709,20 +4709,50 @@ const core = __webpack_require__(470);
 const exec = __webpack_require__(986);
 const io = __webpack_require__(1);
 const tc = __webpack_require__(533);
+const util = __webpack_require__(669)
 
 async function run() {
   try {
     core.debug('Begin Bazelisk Action');
+
+    // define the base github url for bazelisk downloads
+    const BASE_DOWNLOAD_URL =
+      'https://github.com/bazelbuild/bazelisk/releases/download';
+    core.debug(util.format('Base Bazelisk URL: %s', BASE_DOWNLOAD_URL));
+
     const version =
       core.getInput('version', { required : true });
+    core.debug(util.format('version: %s', version));
+
     const bazelBinPath =
       core.getInput('bazel-install-path', { required : true });
+    core.debug(util.format('bazel-install-path: %s', bazelBinPath));
+
     const os =
-      core.getInput('os', { required : true });
+      core.getInput('os', { required : true })
+    core.debug(util.format('os: %s', os));
+
+    let bazeliskBinaryURL = ''
+    switch (util.format("%s", os).toLowerCase()) {
+      case 'darwin':
+      case 'macos':
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-darwin-amd64', BASE_DOWNLOAD_URL, version)
+        break;
+      case 'windows':
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-windows-amd64.exe', BASE_DOWNLOAD_URL, version)
+        break;
+      case 'linux':
+      default:
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-linux-amd64', BASE_DOWNLOAD_URL, version)
+    }
+    core.debug(util.format('bazelisk download url: %s', bazeliskBinaryURL));
 
     const bazeliskPath =
-      await tc.downloadTool(`https://github.com/bazelbuild/bazelisk/releases/download/v${version}/bazelisk-${os}-amd64`);
-    core.debug('Successfully downloaded binary to bazeliskPath');
+      await tc.downloadTool(bazeliskBinaryURL);
+    core.debug(util.format('Downloaded bazelisk binary to %s', bazelBinPath));
 
     // Create directory, move into directory, chmod +x bazel, and add to path.
     await io.mkdirP(bazelBinPath);
@@ -4730,7 +4760,7 @@ async function run() {
     await exec.exec('chmod', ['+x', `${bazelBinPath}/bazel`]);
     await core.addPath(`${bazelBinPath}`);
     core.debug(`Added ${bazelBinPath}/bazel to PATH`);
-    
+
   } catch (err) {
     core.error(err);
     throw new Error(err);

--- a/src/index.js
+++ b/src/index.js
@@ -2,20 +2,50 @@ const core = require('@actions/core');
 const exec = require('@actions/exec');
 const io = require('@actions/io');
 const tc = require('@actions/tool-cache');
+const util = require('util')
 
 async function run() {
   try {
     core.debug('Begin Bazelisk Action');
+
+    // define the base github url for bazelisk downloads
+    const BASE_DOWNLOAD_URL =
+      'https://github.com/bazelbuild/bazelisk/releases/download';
+    core.debug(util.format('Base Bazelisk URL: %s', BASE_DOWNLOAD_URL));
+
     const version =
       core.getInput('version', { required : true });
+    core.debug(util.format('version: %s', version));
+
     const bazelBinPath =
       core.getInput('bazel-install-path', { required : true });
+    core.debug(util.format('bazel-install-path: %s', bazelBinPath));
+
     const os =
-      core.getInput('os', { required : true });
+      core.getInput('os', { required : true })
+    core.debug(util.format('os: %s', os));
+
+    let bazeliskBinaryURL = ''
+    switch (util.format("%s", os).toLowerCase()) {
+      case 'darwin':
+      case 'macos':
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-darwin-amd64', BASE_DOWNLOAD_URL, version)
+        break;
+      case 'windows':
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-windows-amd64.exe', BASE_DOWNLOAD_URL, version)
+        break;
+      case 'linux':
+      default:
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-linux-amd64', BASE_DOWNLOAD_URL, version)
+    }
+    core.debug(util.format('bazelisk download url: %s', bazeliskBinaryURL));
 
     const bazeliskPath =
-      await tc.downloadTool(`https://github.com/bazelbuild/bazelisk/releases/download/v${version}/bazelisk-${os}-amd64`);
-    core.debug('Successfully downloaded binary to bazeliskPath');
+      await tc.downloadTool(bazeliskBinaryURL);
+    core.debug(util.format('Downloaded bazelisk binary to %s', bazelBinPath));
 
     // Create directory, move into directory, chmod +x bazel, and add to path.
     await io.mkdirP(bazelBinPath);
@@ -23,7 +53,7 @@ async function run() {
     await exec.exec('chmod', ['+x', `${bazelBinPath}/bazel`]);
     await core.addPath(`${bazelBinPath}`);
     core.debug(`Added ${bazelBinPath}/bazel to PATH`);
-    
+
   } catch (err) {
     core.error(err);
     throw new Error(err);


### PR DESCRIPTION
In order to use this action in the context of a multi-os build matrix it will be helpful to allow more options to be passed in as the `os` value. Those include case-insensitive versions of the following:

- `macOS`
- `Linux`
- `Darwin`

This will allow us to either pass in the result of `uname` directly, or using `${{ runner.os }}` as part of a build Matrix.
See the following:

```yaml
 jobs:
  build-and-push:
    strategy:
      matrix:
        os: ['ubuntu-16.04', 'macos-latest']
    runs-on: ${{ matrix.os }}
    steps:
      - uses: actions/checkout@v2
        with:
          repository: vsco/bazelisk-action
          path: ./.github/actions/bazelisk-action
      - uses: ./.github/actions/bazelisk-action
        with:
          os: ${{ runner.os }}
```

Also adds a Github Action Workflow to validate changes to this repo going forward, dogfooding if you will.

See: https://github.com/promiseofcake/bazelisk-action/actions/runs/177393280 for a working example.