### PR TITLE
Remove Need / Ability to Specify Runner OS

### DIFF
--- a/.github/workflows/bazelisk.yml
+++ b/.github/workflows/bazelisk.yml
@@ -1,0 +1,25 @@
+name: validate action
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  instal-bazelisk:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      # validate the action works with "default parameters"
+      - name: use vsco/bazelisk-action
+        uses: ./
+        with:
+          os: ${{ runner.os }}
+      - name: Validate bazel install
+        run: |
+          touch WORKSPACE
+          bazel info

--- a/.github/workflows/bazelisk.yml
+++ b/.github/workflows/bazelisk.yml
@@ -17,8 +17,6 @@ jobs:
       # validate the action works with "default parameters"
       - name: use vsco/bazelisk-action
         uses: ./
-        with:
-          os: ${{ runner.os }}
       - name: Validate bazel install
         run: |
           touch WORKSPACE

--- a/.github/workflows/bazelisk.yml
+++ b/.github/workflows/bazelisk.yml
@@ -17,6 +17,8 @@ jobs:
       # validate the action works with "default parameters"
       - name: use vsco/bazelisk-action
         uses: ./
+        with:
+          os: ${{ runner.os }}
       - name: Validate bazel install
         run: |
           touch WORKSPACE

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ jobs:
         # [required]
         # Install path for Bazelisk binaries, defaults to ./.local/bin
         bazel-install-path: './.local/bin'
-        # [required]
-        # The OS of the system that wishes to install Bazelisk.
-        # acceptable values (case-insensitive): ['linux', 'darwin', 'macos']
-        os: 'linux'
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ jobs:
   steps:
     - name: Checkout
       uses: actions/checkout@v2
-      
     - name: Install Bazelisk
       uses: vsco/bazelisk-action@v1.0.0
       with:
@@ -21,7 +20,8 @@ jobs:
         # Install path for Bazelisk binaries, defaults to ./.local/bin
         bazel-install-path: './.local/bin'
         # [required]
-        # The OS of the system that wishes to install Bazelisk. Can be 'darwin' or 'linux'
+        # The OS of the system that wishes to install Bazelisk.
+        # acceptable values (case-insensitive): ['linux', 'darwin', 'macos']
         os: 'linux'
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ jobs:
         # [required]
         # Install path for Bazelisk binaries, defaults to ./.local/bin
         bazel-install-path: './.local/bin'
+        # [required]
+        # The OS of the system that wishes to install Bazelisk.
+        # acceptable values (case-insensitive): ['linux', 'darwin', 'macos']
+        os: 'linux'
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   bazel-install-path:
     description: 'Installation path for Bazelisk binaries (default: ./.local/bin)'
     default: './.local/bin'
+  os:
+    description: 'The type of operating system the system is using, can be "darwin" or "linux" (default: linux)'
+    default: 'linux'
 
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,6 @@ inputs:
   bazel-install-path:
     description: 'Installation path for Bazelisk binaries (default: ./.local/bin)'
     default: './.local/bin'
-  os:
-    description: 'The type of operating system the system is using, can be "darwin" or "linux" (default: linux)'
-    default: 'linux'
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -4709,20 +4709,50 @@ const core = __webpack_require__(470);
 const exec = __webpack_require__(986);
 const io = __webpack_require__(1);
 const tc = __webpack_require__(533);
+const util = __webpack_require__(669)
 
 async function run() {
   try {
     core.debug('Begin Bazelisk Action');
+
+    // define the base github url for bazelisk downloads
+    const BASE_DOWNLOAD_URL =
+      'https://github.com/bazelbuild/bazelisk/releases/download';
+    core.debug(util.format('Base Bazelisk URL: %s', BASE_DOWNLOAD_URL));
+
     const version =
       core.getInput('version', { required : true });
+    core.debug(util.format('version: %s', version));
+
     const bazelBinPath =
       core.getInput('bazel-install-path', { required : true });
+    core.debug(util.format('bazel-install-path: %s', bazelBinPath));
+
     const os =
-      core.getInput('os', { required : true });
+      core.getInput('os', { required : true })
+    core.debug(util.format('os: %s', os));
+
+    let bazeliskBinaryURL = ''
+    switch (util.format("%s", os).toLowerCase()) {
+      case 'darwin':
+      case 'macos':
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-darwin-amd64', BASE_DOWNLOAD_URL, version)
+        break;
+      case 'windows':
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-windows-amd64.exe', BASE_DOWNLOAD_URL, version)
+        break;
+      case 'linux':
+      default:
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-linux-amd64', BASE_DOWNLOAD_URL, version)
+    }
+    core.debug(util.format('bazelisk download url: %s', bazeliskBinaryURL));
 
     const bazeliskPath =
-      await tc.downloadTool(`https://github.com/bazelbuild/bazelisk/releases/download/v${version}/bazelisk-${os}-amd64`);
-    core.debug('Successfully downloaded binary to bazeliskPath');
+      await tc.downloadTool(bazeliskBinaryURL);
+    core.debug(util.format('Downloaded bazelisk binary to %s', bazelBinPath));
 
     // Create directory, move into directory, chmod +x bazel, and add to path.
     await io.mkdirP(bazelBinPath);
@@ -4730,7 +4760,7 @@ async function run() {
     await exec.exec('chmod', ['+x', `${bazelBinPath}/bazel`]);
     await core.addPath(`${bazelBinPath}`);
     core.debug(`Added ${bazelBinPath}/bazel to PATH`);
-    
+
   } catch (err) {
     core.error(err);
     throw new Error(err);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4709,7 +4709,6 @@ const core = __webpack_require__(470);
 const exec = __webpack_require__(986);
 const io = __webpack_require__(1);
 const tc = __webpack_require__(533);
-const os = __webpack_require__(87);
 const util = __webpack_require__(669)
 
 async function run() {
@@ -4729,13 +4728,18 @@ async function run() {
       core.getInput('bazel-install-path', { required : true });
     core.debug(util.format('bazel-install-path: %s', bazelBinPath));
 
+    const os =
+      core.getInput('os', { required : true })
+    core.debug(util.format('os: %s', os));
+
     let bazeliskBinaryURL = ''
-    switch (os.platform()) {
+    switch (util.format("%s", os).toLowerCase()) {
       case 'darwin':
+      case 'macos':
         bazeliskBinaryURL =
           util.format('%s/v%s/bazelisk-darwin-amd64', BASE_DOWNLOAD_URL, version)
         break;
-      case 'win32':
+      case 'windows':
         bazeliskBinaryURL =
           util.format('%s/v%s/bazelisk-windows-amd64.exe', BASE_DOWNLOAD_URL, version)
         break;

--- a/dist/index.js
+++ b/dist/index.js
@@ -4709,6 +4709,7 @@ const core = __webpack_require__(470);
 const exec = __webpack_require__(986);
 const io = __webpack_require__(1);
 const tc = __webpack_require__(533);
+const os = __webpack_require__(87);
 const util = __webpack_require__(669)
 
 async function run() {
@@ -4728,18 +4729,13 @@ async function run() {
       core.getInput('bazel-install-path', { required : true });
     core.debug(util.format('bazel-install-path: %s', bazelBinPath));
 
-    const os =
-      core.getInput('os', { required : true })
-    core.debug(util.format('os: %s', os));
-
     let bazeliskBinaryURL = ''
-    switch (util.format("%s", os).toLowerCase()) {
+    switch (os.platform()) {
       case 'darwin':
-      case 'macos':
         bazeliskBinaryURL =
           util.format('%s/v%s/bazelisk-darwin-amd64', BASE_DOWNLOAD_URL, version)
         break;
-      case 'windows':
+      case 'win32':
         bazeliskBinaryURL =
           util.format('%s/v%s/bazelisk-windows-amd64.exe', BASE_DOWNLOAD_URL, version)
         break;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ const core = require('@actions/core');
 const exec = require('@actions/exec');
 const io = require('@actions/io');
 const tc = require('@actions/tool-cache');
-const os = require('os');
 const util = require('util')
 
 async function run() {
@@ -22,13 +21,18 @@ async function run() {
       core.getInput('bazel-install-path', { required : true });
     core.debug(util.format('bazel-install-path: %s', bazelBinPath));
 
+    const os =
+      core.getInput('os', { required : true })
+    core.debug(util.format('os: %s', os));
+
     let bazeliskBinaryURL = ''
-    switch (os.platform()) {
+    switch (util.format("%s", os).toLowerCase()) {
       case 'darwin':
+      case 'macos':
         bazeliskBinaryURL =
           util.format('%s/v%s/bazelisk-darwin-amd64', BASE_DOWNLOAD_URL, version)
         break;
-      case 'win32':
+      case 'windows':
         bazeliskBinaryURL =
           util.format('%s/v%s/bazelisk-windows-amd64.exe', BASE_DOWNLOAD_URL, version)
         break;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const core = require('@actions/core');
 const exec = require('@actions/exec');
 const io = require('@actions/io');
 const tc = require('@actions/tool-cache');
+const os = require('os');
 const util = require('util')
 
 async function run() {
@@ -21,18 +22,13 @@ async function run() {
       core.getInput('bazel-install-path', { required : true });
     core.debug(util.format('bazel-install-path: %s', bazelBinPath));
 
-    const os =
-      core.getInput('os', { required : true })
-    core.debug(util.format('os: %s', os));
-
     let bazeliskBinaryURL = ''
-    switch (util.format("%s", os).toLowerCase()) {
+    switch (os.platform()) {
       case 'darwin':
-      case 'macos':
         bazeliskBinaryURL =
           util.format('%s/v%s/bazelisk-darwin-amd64', BASE_DOWNLOAD_URL, version)
         break;
-      case 'windows':
+      case 'win32':
         bazeliskBinaryURL =
           util.format('%s/v%s/bazelisk-windows-amd64.exe', BASE_DOWNLOAD_URL, version)
         break;

--- a/src/index.js
+++ b/src/index.js
@@ -2,20 +2,50 @@ const core = require('@actions/core');
 const exec = require('@actions/exec');
 const io = require('@actions/io');
 const tc = require('@actions/tool-cache');
+const util = require('util')
 
 async function run() {
   try {
     core.debug('Begin Bazelisk Action');
+
+    // define the base github url for bazelisk downloads
+    const BASE_DOWNLOAD_URL =
+      'https://github.com/bazelbuild/bazelisk/releases/download';
+    core.debug(util.format('Base Bazelisk URL: %s', BASE_DOWNLOAD_URL));
+
     const version =
       core.getInput('version', { required : true });
+    core.debug(util.format('version: %s', version));
+
     const bazelBinPath =
       core.getInput('bazel-install-path', { required : true });
+    core.debug(util.format('bazel-install-path: %s', bazelBinPath));
+
     const os =
-      core.getInput('os', { required : true });
+      core.getInput('os', { required : true })
+    core.debug(util.format('os: %s', os));
+
+    let bazeliskBinaryURL = ''
+    switch (util.format("%s", os).toLowerCase()) {
+      case 'darwin':
+      case 'macos':
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-darwin-amd64', BASE_DOWNLOAD_URL, version)
+        break;
+      case 'windows':
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-windows-amd64.exe', BASE_DOWNLOAD_URL, version)
+        break;
+      case 'linux':
+      default:
+        bazeliskBinaryURL =
+          util.format('%s/v%s/bazelisk-linux-amd64', BASE_DOWNLOAD_URL, version)
+    }
+    core.debug(util.format('bazelisk download url: %s', bazeliskBinaryURL));
 
     const bazeliskPath =
-      await tc.downloadTool(`https://github.com/bazelbuild/bazelisk/releases/download/v${version}/bazelisk-${os}-amd64`);
-    core.debug('Successfully downloaded binary to bazeliskPath');
+      await tc.downloadTool(bazeliskBinaryURL);
+    core.debug(util.format('Downloaded bazelisk binary to %s', bazelBinPath));
 
     // Create directory, move into directory, chmod +x bazel, and add to path.
     await io.mkdirP(bazelBinPath);
@@ -23,7 +53,7 @@ async function run() {
     await exec.exec('chmod', ['+x', `${bazelBinPath}/bazel`]);
     await core.addPath(`${bazelBinPath}`);
     core.debug(`Added ${bazelBinPath}/bazel to PATH`);
-    
+
   } catch (err) {
     core.error(err);
     throw new Error(err);


### PR DESCRIPTION
We can, and I believe should, infer the Github Runner's OS during execution of the action, as opposed to requiring the user to pass a value in. By doing this, we can ensure that the action can be used in a multiple-os-build-matrix without issue.

See #1 for the original non-breaking change implementation.

In the event we believe this is the path to take, we probably need to start versioning this action and create a v1 branch off of the latest main `HEAD` commit before we merge this in and then begin referring to it as v2.

This PR also introduces the a local Github Action to validate that this action works / continues to work as we iterate on it.