### PR TITLE
fix the deprecated “add-path”

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ async function run() {
     await io.mkdirP(bazelBinPath);
     await io.mv(bazeliskPath, `${bazelBinPath}/bazel`);
     await exec.exec('chmod', ['+x', `${bazelBinPath}/bazel`]);
-    await exec.exec('echo',[`${bazelBinPath}`',">> $GITHUB_PATH"]);
+    await exec.exec('echo',[`${bazelBinPath}`,'>> $GITHUB_PATH']);
     core.debug(`Added ${bazelBinPath}/bazel to PATH`);
     
   } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ async function run() {
     await io.mkdirP(bazelBinPath);
     await io.mv(bazeliskPath, `${bazelBinPath}/bazel`);
     await exec.exec('chmod', ['+x', `${bazelBinPath}/bazel`]);
-    await core.addPath(`${bazelBinPath}`);
+    await exec.exec('echo',[`${bazelBinPath}`',">> $GITHUB_PATH"]);
     core.debug(`Added ${bazelBinPath}/bazel to PATH`);
     
   } catch (err) {


### PR DESCRIPTION
follow this guide
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
and
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files