### PR TITLE
Update README, removing incorrect version reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Install Bazelisk
-      uses: vsco/bazelisk-action@v1.1
+      uses: vsco/bazelisk-action@1.1
       with:
         # [required]
         # Version of Bazelisk we would like to install, defaults to 1.5.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Install Bazelisk
-      uses: vsco/bazelisk-action@v1.0.0
+      uses: vsco/bazelisk-action@v1.1
       with:
         # [required]
         # Version of Bazelisk we would like to install, defaults to 1.5.0


### PR DESCRIPTION
Tag v1.0.0 doesn't exist, usage can't be copy/pasted.